### PR TITLE
Support pull_request_target event

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,8 @@ async function run(): Promise<void> {
     core.debug(`filename: ${filename}`)
 
     switch (process.env.GITHUB_EVENT_NAME) {
-      case 'pull_request': {
+      case 'pull_request': 
+      case 'pull_request_target': {
         const {GITHUB_BASE_REF = ''} = process.env
         core.debug(`GITHUB_BASE_REF: ${GITHUB_BASE_REF}`)
         const artifactPath = await downloadArtifacts(GITHUB_BASE_REF)

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ async function run(): Promise<void> {
     core.debug(`filename: ${filename}`)
 
     switch (process.env.GITHUB_EVENT_NAME) {
-      case 'pull_request': 
+      case 'pull_request':
       case 'pull_request_target': {
         const {GITHUB_BASE_REF = ''} = process.env
         core.debug(`GITHUB_BASE_REF: ${GITHUB_BASE_REF}`)


### PR DESCRIPTION
The pull_request_target is used for pull requests originating from forks with read only permissions by default.
This is required to use [marocchino/sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment) in PRs from forks. See https://github.com/marocchino/sticky-pull-request-comment/issues/930