### PR TITLE
Make it possible to skip package coverage

### DIFF
--- a/__tests__/__snapshots__/functions.test.ts.snap
+++ b/__tests__/__snapshots__/functions.test.ts.snap
@@ -30,7 +30,8 @@ exports[`Dont Fail on negative difference if negative_difference_threshold is se
 | utils.ts | 🟠 70.94% | 🟠 69% | 🔴 -1.94% |
 | **Overall Coverage** | **🟢 50.51%** | **🟢 49%** | **🔴 -1.51%** |
 
-_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`49%\`"
+_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`49%\`
+"
 `;
 
 exports[`Fail if negative_difference_threshold is set and exceeded 1`] = `
@@ -64,7 +65,8 @@ exports[`Fail if negative_difference_threshold is set and exceeded 2`] = `
 | utils.ts | 🟠 70.94% | 🟠 69% | 🔴 -1.94% |
 | **Overall Coverage** | **🟢 50.51%** | **🟢 49%** | **🔴 -1.51%** |
 
-_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`49%\`"
+_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`49%\`
+"
 `;
 
 exports[`Fail if overall coverage is below fail threshold 1`] = `
@@ -98,7 +100,8 @@ exports[`Fail if overall coverage is below fail threshold 2`] = `
 | utils.ts | 🟠 70.94% | 🟠 70.94% | ⚪ 0% |
 | **Overall Coverage** | **🔴 50.51%** | **🔴 50.51%** | **⚪ 0%** |
 
-_Minimum allowed coverage is_ \`99%\`_, this run produced_ \`50.51%\`"
+_Minimum allowed coverage is_ \`99%\`_, this run produced_ \`50.51%\`
+"
 `;
 
 exports[`Fail on negative difference 1`] = `
@@ -132,7 +135,8 @@ exports[`Fail on negative difference 2`] = `
 | utils.ts | 🟠 70.94% | 🟠 69% | 🔴 -1.94% |
 | **Overall Coverage** | **🟢 50.51%** | **🟢 49%** | **🔴 -1.51%** |
 
-_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`49%\`"
+_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`49%\`
+"
 `;
 
 exports[`Generate Base Clover Markdown 1`] = `
@@ -165,7 +169,8 @@ exports[`Generate Base Clover Markdown 2`] = `
 | utils.ts | 🟠 70.94% |
 | **Overall Coverage** | **🟢 50.51%** |
 
-_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`50.51%\`"
+_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`50.51%\`
+"
 `;
 
 exports[`Generate Base Cobertura Markdown 1`] = `
@@ -198,7 +203,8 @@ exports[`Generate Base Cobertura Markdown 2`] = `
 | utils.ts | 🟠 67.36% |
 | **Overall Coverage** | **🟢 49.83%** |
 
-_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`49.83%\`"
+_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`49.83%\`
+"
 `;
 
 exports[`Generate Diffed Clover Markdown 1`] = `
@@ -231,7 +237,8 @@ exports[`Generate Diffed Clover Markdown 2`] = `
 | utils.ts | 🟠 70.94% | 🟠 70.94% | ⚪ 0% |
 | **Overall Coverage** | **🟢 50.51%** | **🟢 50.51%** | **⚪ 0%** |
 
-_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`50.51%\`"
+_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`50.51%\`
+"
 `;
 
 exports[`Generate Diffed Cobertura Markdown 1`] = `
@@ -264,7 +271,8 @@ exports[`Generate Diffed Cobertura Markdown 2`] = `
 | utils.ts | 🟠 67.36% | 🟠 67.36% | ⚪ 0% |
 | **Overall Coverage** | **🟢 49.83%** | **🟢 49.83%** | **⚪ 0%** |
 
-_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`49.83%\`"
+_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`49.83%\`
+"
 `;
 
 exports[`Only list changed files 1`] = `
@@ -290,5 +298,6 @@ exports[`Only list changed files 2`] = `
 | utils.ts | 🟠 70.94% | 🟠 69% | 🔴 -1.94% |
 | **Overall Coverage** | **🟢 50.51%** | **🟢 49%** | **🔴 -1.51%** |
 
-_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`49%\`"
+_Minimum allowed coverage is_ \`0%\`_, this run produced_ \`49%\`
+"
 `;

--- a/__tests__/functions.test.ts
+++ b/__tests__/functions.test.ts
@@ -86,8 +86,7 @@ test('Generate Base Clover Markdown', async () => {
 test('Generate Base Cobertura Markdown', async () => {
   const coverage = await loadJSONFixture('cobertura-parsed.json')
   await generateMarkdown(coverage)
-  let stdoutWriteCalls = getStdoutWriteCalls()
-  expect(stdoutWriteCalls).toMatchSnapshot()
+  expect(getStdoutWriteCalls()).toMatchSnapshot()
   expect(await getGithubStepSummary()).toMatchSnapshot()
 })
 

--- a/__tests__/functions.test.ts
+++ b/__tests__/functions.test.ts
@@ -79,8 +79,7 @@ test('add overall row with base coverage', async () => {
 test('Generate Base Clover Markdown', async () => {
   const coverage = await loadJSONFixture('clover-parsed.json')
   await generateMarkdown(coverage)
-  let stdoutWriteCalls1 = getStdoutWriteCalls()
-  expect(stdoutWriteCalls1).toMatchSnapshot()
+  expect(getStdoutWriteCalls()).toMatchSnapshot()
   expect(await getGithubStepSummary()).toMatchSnapshot()
 })
 

--- a/__tests__/functions.test.ts
+++ b/__tests__/functions.test.ts
@@ -79,14 +79,16 @@ test('add overall row with base coverage', async () => {
 test('Generate Base Clover Markdown', async () => {
   const coverage = await loadJSONFixture('clover-parsed.json')
   await generateMarkdown(coverage)
-  expect(getStdoutWriteCalls()).toMatchSnapshot()
+  let stdoutWriteCalls1 = getStdoutWriteCalls()
+  expect(stdoutWriteCalls1).toMatchSnapshot()
   expect(await getGithubStepSummary()).toMatchSnapshot()
 })
 
 test('Generate Base Cobertura Markdown', async () => {
   const coverage = await loadJSONFixture('cobertura-parsed.json')
   await generateMarkdown(coverage)
-  expect(getStdoutWriteCalls()).toMatchSnapshot()
+  let stdoutWriteCalls = getStdoutWriteCalls()
+  expect(stdoutWriteCalls).toMatchSnapshot()
   expect(await getGithubStepSummary()).toMatchSnapshot()
 })
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -147,6 +147,7 @@ test('getInputs', () => {
     negativeDifferenceBy: 'package',
     negativeDifferenceThreshold: -0,
     retention: undefined,
+    skipPackageCoverage: false,
     onlyListChangedFiles: false,
     //This is a cheat
     withBaseCoverageTemplate: f.withBaseCoverageTemplate,

--- a/dist/with-base-coverage.hbs
+++ b/dist/with-base-coverage.hbs
@@ -6,9 +6,11 @@
 {{/if}}
 | Package | Base Coverage | New Coverage | Difference |
 | ------- | ------------- | ------------ | ---------- |
+{{#if show_package_coverage}}
 {{#each coverage}}
 | {{package}} | {{base_coverage}} | {{new_coverage}} | {{difference}} |
 {{/each}}
+{{/if}}
 {{#with overall_coverage}}
 | **{{package}}** | **{{base_coverage}}** | **{{new_coverage}}** | **{{difference}}** |
 {{/with}}

--- a/dist/without-base-coverage.hbs
+++ b/dist/without-base-coverage.hbs
@@ -6,9 +6,11 @@
 {{/if}}
 | Package |    Coverage   |
 | ------- | ------------- |
+{{#if show_package_coverage}}
 {{#each coverage}}
 | {{package}} | {{base_coverage}} |
 {{/each}}
+{{/if}}
 {{#with overall_coverage}}
 | **{{package}}** | **{{base_coverage}}** |
 {{/with}}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,6 +28,7 @@ export interface Inputs {
   withoutBaseCoverageTemplate: string
   negativeDifferenceThreshold: number
   onlyListChangedFiles: boolean
+  skipPackageCoverage: boolean
 }
 
 export interface Files {
@@ -43,6 +44,7 @@ export interface HandlebarContextCoverage {
 
 export interface HandlebarContext {
   coverage_badge?: string
+  show_package_coverage?: boolean
   minimum_allowed_coverage?: string
   new_coverage?: string
   coverage: HandlebarContextCoverage[]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -330,7 +330,8 @@ export function getInputs(): Inputs {
   const filename = core.getInput('filename', {required: true})
   const markdownFilename =
     core.getInput('markdown_filename') || 'code-coverage-results'
-  const badge = core.getInput('badge') === 'true' ? true : false
+  const badge = core.getInput('badge') === 'true'
+  const skipPackageCoverage = core.getInput('skip_package_coverage') === 'true'
   const overallCoverageFailThreshold = Math.abs(
     parseInt(core.getInput('overall_coverage_fail_threshold') || '0')
   )
@@ -400,7 +401,8 @@ export function getInputs(): Inputs {
     withoutBaseCoverageTemplate,
     withBaseCoverageTemplate,
     negativeDifferenceThreshold,
-    onlyListChangedFiles
+    onlyListChangedFiles,
+    skipPackageCoverage
   }
 }
 

--- a/templates/with-base-coverage.hbs
+++ b/templates/with-base-coverage.hbs
@@ -6,9 +6,11 @@
 {{/if}}
 | Package | Base Coverage | New Coverage | Difference |
 | ------- | ------------- | ------------ | ---------- |
+{{#if show_package_coverage}}
 {{#each coverage}}
 | {{package}} | {{base_coverage}} | {{new_coverage}} | {{difference}} |
 {{/each}}
+{{/if}}
 {{#with overall_coverage}}
 | **{{package}}** | **{{base_coverage}}** | **{{new_coverage}}** | **{{difference}}** |
 {{/with}}

--- a/templates/without-base-coverage.hbs
+++ b/templates/without-base-coverage.hbs
@@ -6,9 +6,11 @@
 {{/if}}
 | Package |    Coverage   |
 | ------- | ------------- |
+{{#if show_package_coverage}}
 {{#each coverage}}
 | {{package}} | {{base_coverage}} |
 {{/each}}
+{{/if}}
 {{#with overall_coverage}}
 | **{{package}}** | **{{base_coverage}}** |
 {{/with}}


### PR DESCRIPTION
Sometimes the package listing can become really verbose. This change allows the user of the action to only show overall coverage. Example:

<img width="505" alt="image" src="https://github.com/user-attachments/assets/12759376-5af6-4e34-9211-9c80af33d701" />
