### PR TITLE
update repository URLs in package.json and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Code Coverage Report
 
-[![ci](https://github.com/tm1000/code-coverage-report-action/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tm1000/code-coverage-report-action/actions/workflows/ci.yml)
+[![ci](https://github.com/clearlyip/code-coverage-report-action/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/clearlyip/code-coverage-report-action/actions/workflows/ci.yml)
 
-This action looks for a defined `clover` or `cobertura` file and parses that to give you feedback not only about current coverage but also coverage against the base a pull request might be merging into. It uses Github's workflow artifacts to store the raw coverage files for later comparison and it generates a markdown file that is appended to the [job summary](https://github.com/tm1000/code-coverage-report-action/actions/runs/3109427303) and that can also be used in something like [marocchino/sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment). (See our workflows for examples)
+This action looks for a defined `clover` or `cobertura` file and parses that to give you feedback not only about current coverage but also coverage against the base a pull request might be merging into. It uses Github's workflow artifacts to store the raw coverage files for later comparison and it generates a markdown file that is appended to the [job summary](https://github.com/clearlyip/code-coverage-report-action/actions/runs/3109427303) and that can also be used in something like [marocchino/sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment). (See our workflows for examples)
 
 ![Example Comment](/images/image1.png?raw=true 'Example Comment')
 

--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tm1000/code-coverage-report-action.git"
+    "url": "git+https://github.com/clearlyip/code-coverage-report-action.git"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/tm1000/code-coverage-report-action/issues"
+    "url": "https://github.com/clearlyip/code-coverage-report-action/issues"
   },
-  "homepage": "https://github.com/tm1000/code-coverage-report-action#readme",
+  "homepage": "https://github.com/clearlyip/code-coverage-report-action#readme",
   "dependencies": {
     "@actions/artifact": "^2.3.2",
     "@actions/core": "^1.11.1",


### PR DESCRIPTION
## Changes
- Updated all repository URLs from tm1000 to clearlyip organization
- Modified badge URLs in README.md
- Updated repository URLs in package.json

This change reflects the transfer of repository ownership from tm1000 to clearlyip organization.