### PR TITLE
remove format scripts after prettier integration into eslint in d1faee8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           node-version: 20.x
       - run: npm ci
-      - run: npm run format:check >> "${GITHUB_STEP_SUMMARY}"
       - run: npm run lint
       - run: npm run test >> "${GITHUB_STEP_SUMMARY}"
       - run: npm run package

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "package": "ncc build src/main.ts --source-map --license licenses.txt",
     "watch": "ncc build src/main.ts --watch",
     "test": "jest",
-    "all": "npm run format && npm run lint && npm run package && npm test"
+    "all": "npm run lint && npm run package && npm test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Changes
- Remove `format:check` script execution from CI workflow
- Remove `format` script from `all` script in `package.json`
- Unify quotation style in CI workflow (single → double)

## Background
Since prettier was integrated into eslint in d1faee84a8384b0833fe368c8e391f9c837049c1, format-related scripts are no longer needed.